### PR TITLE
Fix line-height snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       },
       {
         "language": "scss",
-        "path": "./snippets/line-heigth.json"
+        "path": "./snippets/line-height.json"
       },
       {
         "language": "scss",


### PR DESCRIPTION
It fixes line-height snippet that isn't showing up

![deepin-screen-recorder_Select area_20191202145333](https://user-images.githubusercontent.com/13206817/69982802-aaa53a00-150b-11ea-9bbc-f6b0d297b074.gif)
